### PR TITLE
V3 and re-implementation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
 # Trello plugin all-in-one
-> You all-in-one [Trello](https://trello.com/) board plugin
+> Your all-in-one [Trello](https://trello.com/) board plugin
 
 ![Chrome Web Store](https://img.shields.io/chrome-web-store/d/pnfioopglhebphfgkagefdmajgibahkk.svg?style=for-the-badge&label=Chrome%20users&ogo=google-chrome&logoColor=white)
 ![Chrome Web Store](https://img.shields.io/chrome-web-store/v/pnfioopglhebphfgkagefdmajgibahkk.svg?style=for-the-badge&logo=google-chrome&logoColor=white)
@@ -8,14 +8,13 @@
 Get it from Chrome Store! [Trello plugin all-in-one](https://chrome.google.com/webstore/detail/trello-plugin-all-in-one/pnfioopglhebphfgkagefdmajgibahkk?hl=en)
 
 ## Background
-Trello boards are really useful for lots of purposes. However, there are lots of features that it could have provided such as
-- show card age
-- show card number
-- show card label name
-- show card count in each column
-- show true age for each card (the time that each card has been in the column)
+Trello boards are really useful for lots of purposes. However, there are lots of missing features that users ask for, such as
+- card number
+- card label name
+- total number of cards in each column
+- true car age (the time that each card has been moved to a column)
 
-People started to build lots of small extensions to power up their Trello boards. Then one day, I found that half of my Chrome extentions were Trello-related. I started to think about if I could create an all-in-one plugin which could fulfill all my purposes.
+People started to build lots of small extensions to power up their Trello boards. Then one day, I found that half of my Chrome extensions were Trello-related. I started to think about if I should create an all-in-one plugin which could fulfill all my purposes.
 
 ## Features
 
@@ -30,7 +29,7 @@ Display the missing Trello card number.
 
 ### Card count for each column
 
-Display the card count at top of the columns.
+Display the total number of cards in each column.
 
 ### Label name
 

--- a/Readme.md
+++ b/Readme.md
@@ -4,6 +4,10 @@
 ![Chrome Web Store](https://img.shields.io/chrome-web-store/d/pnfioopglhebphfgkagefdmajgibahkk.svg?style=for-the-badge&label=Chrome%20users&ogo=google-chrome&logoColor=white)
 ![Chrome Web Store](https://img.shields.io/chrome-web-store/v/pnfioopglhebphfgkagefdmajgibahkk.svg?style=for-the-badge&logo=google-chrome&logoColor=white)
 
+## Update after the Trello release around 2023/10/20
+There was a release of Trello website on 20 Oct 2023, which removed hidden card number and the total number of each list/column. I had to re-implement these features.
+It took me some time because Chrome Web Store no longer accepts Manifest V2 extensions. I had to migrate it to Manifest V3.
+
 ## Supported Browser
 Get it from Chrome Store! [Trello plugin all-in-one](https://chrome.google.com/webstore/detail/trello-plugin-all-in-one/pnfioopglhebphfgkagefdmajgibahkk?hl=en)
 
@@ -11,7 +15,7 @@ Get it from Chrome Store! [Trello plugin all-in-one](https://chrome.google.com/w
 Trello boards are really useful for lots of purposes. However, there are lots of missing features that users ask for, such as
 - card number
 - card label name
-- total number of cards in each column
+- total number of cards in each list/column
 - true car age (the time that each card has been moved to a column)
 
 People started to build lots of small extensions to power up their Trello boards. Then one day, I found that half of my Chrome extensions were Trello-related. I started to think about if I should create an all-in-one plugin which could fulfill all my purposes.
@@ -67,6 +71,6 @@ Just refresh the page, it will work as expected.
 Author: [@derrickqin](https://github.com/derrickqin)
 
 ## Copyright and License
-❗️ This extension is not sponsored by, endorsed by, or an official project of GitHub. This is a personal project and is developed solely for providing additional functionalities on GitHub website.
+❗️ Trello is a product of Atlassian Corporation. This extension is not sponsored by, endorsed by, or an official project of Trello. This is a personal project and is developed solely for providing additional functionalities on Trello website.
 
 > [MIT license](https://opensource.org/licenses/MIT) (MIT)

--- a/background.js
+++ b/background.js
@@ -1,12 +1,12 @@
 chrome.tabs.onCreated.addListener(decorate);
 chrome.tabs.onUpdated.addListener(function (tabId, info, tab) {
-  if (info.status == 'complete') decorate(tabId, tab);
+  if (info.status === 'complete') {
+    decorate(tabId, tab);
+  }
 });
 
 function decorate(tabId, tab) {
-  if (tab.url && tab.url.indexOf("https://trello.com") != -1) {
-    change(tab.id, "columnCount", "css/count.css");
-    change(tab.id, "cardId", "css/number.css");
+  if (typeof tab !== 'undefined' && tab.url && tab.url.indexOf("https://trello.com") !== -1) {
     change(tab.id, "labelName", "css/label.css");
   }
 }
@@ -14,7 +14,10 @@ function decorate(tabId, tab) {
 function change(tabId, key, cssFile) {
   chrome.storage.sync.get(key, function(item) {
     if (!item[key]) {
-      chrome.tabs.insertCSS(tabId, { file: cssFile });
+      chrome.scripting.insertCSS({
+        target: { tabId: tabId },
+        files: [cssFile],
+      });
     }
   });
 }

--- a/css/count.css
+++ b/css/count.css
@@ -1,7 +1,0 @@
-/*
-card count
-*/
-.list-header-num-cards {
-  display: inline-block!important;
-  white-space: nowrap;
-}

--- a/css/label.css
+++ b/css/label.css
@@ -1,20 +1,23 @@
-/*
-label color
-If label has no name, it will show a narrow color bar
-*/
-.list-card-labels .card-label {
+/*!**/
+/*Show full label name after the Trello release around 2023/10/20*/
+/**!*/
+button[data-testid="compact-card-label"] {
+  color: black; /* or any color you prefer */
   font-size: .8rem;
   height: inherit!important;
   padding: 0 0.4em!important;
   margin-right: 1px;
   width: auto!important;
-  line-height:1.2rem!important
+  line-height:1.2rem!important;
+  max-width: 100px!important;
+  min-width: 40px!important;
 }
 
-/*
-Show full label name after the trello release around 2017/08/07
-*/
-.card-label.mod-card-front {
-  max-width: 100px!important;
-  min-width: 0px!important;
+/*!**/
+/*label color*/
+/*If label has no name, it will show a narrow color bar*/
+/**!*/
+button[aria-label*="none"] {
+  color: black; /* or any color you prefer */
+  height: 16px!important;
 }

--- a/css/number.css
+++ b/css/number.css
@@ -1,8 +1,0 @@
-/*
-card number
-*/
-.card-short-id {
-  display: inline-block!important;
-  font-weight: bold;
-  padding-right: 5px;
-}

--- a/manifest.json
+++ b/manifest.json
@@ -1,26 +1,25 @@
 {
-  "manifest_version": 2,
-  "name": "Trello plugin all-in-one",
+  "manifest_version": 3,
+  "name": "Trello plugin all-in-one - Truello",
   "short_name": "Truello",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Tired of having too many extensions for Trello? Add missing features in ONE Chrome extension: Card age, number, count and lable name",
   "author" : "Derrick Qin",
+  "host_permissions": ["https://trello.com/*"],
   "permissions": [
     "tabs",
-    "https://trello.com/*",
-    "storage"
+    "storage",
+    "scripting"
   ],
   "content_scripts": [ {
     "js": [ "thirdPartyLib/moment.js", "truello.js" ],
+    "run_at": "document_idle",
     "matches": [ "https://trello.com/*" ]
   } ],
-  "background":{
-    "scripts": [
-      "background.js"
-    ]
+  "background": {
+    "service_worker": "background.js"
   },
   "options_ui": {
-    "page": "options.html",
-    "chrome_style": true
+    "page": "options.html"
   }
 }

--- a/options.html
+++ b/options.html
@@ -15,26 +15,33 @@
 </head>
 
 <body>
-  <h3>Choose below options if you want to disable some features</h3>
+<p>Choose below options if you want to <b> DISABLE </b> some features</p>
 
   <div class="option">
     <label>
-      <input type="checkbox" id="columnCount">
-      Column Count
+      <input type="checkbox" id="cardAge">
+      Hide Card Age
+    </label>
+  </div>
+
+  <div class="option">
+    <label>
+      <input type="checkbox" id="cardCountInList">
+      Hide Card Count in list
     </label>
   </div>
 
   <div class="option">
     <label>
       <input type="checkbox" id="cardId">
-      Card ID's
+      Hide Card ID's
     </label>
   </div>
 
   <div class="option">
     <label>
       <input type="checkbox" id="labelName">
-      Full Label Names
+      Hide Label Names
     </label>
   </div>
 

--- a/options.js
+++ b/options.js
@@ -1,14 +1,16 @@
 function save_options() {
-  var columnCount = document.getElementById('columnCount').checked;
-  var cardId = document.getElementById('cardId').checked;
-  var labelName = document.getElementById('labelName').checked;
+  let cardAge = document.getElementById('cardAge').checked;
+  let cardCountInList = document.getElementById('cardCountInList').checked;
+  let cardId = document.getElementById('cardId').checked;
+  let labelName = document.getElementById('labelName').checked;
 
   chrome.storage.sync.set({
-    columnCount: columnCount,
+    cardAge: cardAge,
+    cardCountInList: cardCountInList,
     cardId: cardId,
     labelName: labelName
   }, function() {
-    var status = document.getElementById('status');
+    let status = document.getElementById('status');
     status.textContent = 'Options saved.';
     setTimeout(function() {
       status.textContent = '';
@@ -18,11 +20,13 @@ function save_options() {
 
 function restore_options() {
   chrome.storage.sync.get({
-    columnCount: false,
+    cardAge: false,
+    cardCountInList: false,
     cardId: false,
     labelName: false
   }, function(items) {
-    document.getElementById('columnCount').checked = items.columnCount;
+    document.getElementById('cardAge').checked = items.cardAge;
+    document.getElementById('cardCountInList').checked = items.cardCountInList;
     document.getElementById('cardId').checked = items.cardId;
     document.getElementById('labelName').checked = items.labelName;
   });

--- a/truello.js
+++ b/truello.js
@@ -1,40 +1,79 @@
-window.addEventListener("load", function () {
-  addAging();
-});
+setInterval(function () {
+  chrome.storage.sync.get(null).then((options) => {
+    change(options);
+  });
+}, 3000);
 
+function showCardId(cardHref, card) {
+  let match = cardHref.match(/\/(\d+)-/);
+  if (match) {
+    // remove existing label in any
+    card.innerHTML = card.innerHTML.replace(/<b class="card-short-id">#\d+<\/b>/, '');
 
-function addAging() {
-
-
-  var cards = document.querySelectorAll(".list-card, .ui-droppable");
-
-  for (index = 0; index < cards.length; index++) {
-    (function (index) {
-      var agingElements = cards[index].getElementsByClassName("trello-card-aging");
-      if (agingElements === undefined || agingElements.length === 0) {
-        var xhr = new XMLHttpRequest();
-        xhr.onreadystatechange = function () {
-          if (xhr.readyState == 4 && xhr.status == 200) {
-            var json = xhr.responseText;
-            json = json.replace(/^[^(]*\(([\S\s]+)\);?$/, '$1');
-            json = JSON.parse(json);
-
-            var idList = json["idList"];
-            var actions = json["actions"];
-            var date = json.actions.filter(function (action) {
-              return action.type === 'createCard' || action.type === 'copyCard' || (action.data.listAfter && action.data.listAfter.id === idList)
-            }).shift().date;
-            var div = document.createElement("div");
-            div.innerHTML = '<span class="trello-card-aging" style="color:purple;">' + moment(date).fromNow() + '</span>';
-            jsBadgeEle = cards[index].getElementsByClassName('badges')[0];
-            jsBadgeEle.insertBefore(div, jsBadgeEle.firstChild);
-          }
-        };
-        var cardHref = cards[index].getAttribute('href');
-        xhr.open("GET", 'https://' + document.domain + cardHref + '.json');
-        xhr.send();
-      }
-    })(index);
+    card.innerHTML = `<b class="card-short-id">#${match[1]}</b> ${card.innerHTML}`
   }
+}
 
+function showCardCountInList() {
+  let lists = document.querySelectorAll("div[data-testid=\"list\"]");
+  for (let index = 0; index < lists.length; index++) {
+    let list = lists[index];
+    let cardCount = list.querySelectorAll("li[data-testid=\"list-card\"]").length;
+    let listName = list.querySelector("h2[data-testid=\"list-name\"]");
+    let cardCountLabel;
+    if (cardCount === 1) {
+      cardCountLabel = `<div class="card-count-in-list" style="color:grey;">${cardCount} card</div>`;
+    } else {
+      cardCountLabel = `<div class="card-count-in-list" style="color:grey;">${cardCount} cards</div>`;
+    }
+
+    // remove existing label if any
+    listName.innerHTML = listName.innerHTML.replace(/<div class="card-count-in-list" style="color:grey;">\d+\scards?<\/div>/, '');
+
+    listName.innerHTML = listName.innerHTML + cardCountLabel;
+  }
+}
+
+function change(options) {
+  // fix after the Trello release around 2023/10/20
+  if (!options['cardCountInList']) {
+    showCardCountInList()
+  }
+  let cards = document.querySelectorAll("a[data-testid=\"card-name\"]");
+
+  for (let index = 0; index < cards.length; index++) {
+    let cardHref = cards[index].getAttribute('href');
+
+    // show card ID
+    if (!options['cardId']) {
+      showCardId(cardHref, cards[index]);
+    }
+
+    if (!options['cardAge']) {
+      (function (index) {
+        let agingElements = cards[index].getElementsByClassName("trello-card-aging");
+        if (agingElements === undefined || agingElements.length === 0) {
+          let xhr = new XMLHttpRequest();
+          xhr.onreadystatechange = function () {
+            if (xhr.readyState == 4 && xhr.status == 200) {
+              let json = xhr.responseText;
+              json = json.replace(/^[^(]*\(([\S\s]+)\);?$/, '$1');
+              json = JSON.parse(json);
+
+              let idList = json["idList"];
+              let date = json.actions.filter(function (action) {
+                return action.type === 'createCard' || action.type === 'copyCard' || (action.data.listAfter && action.data.listAfter.id === idList)
+              }).shift().date;
+              let trueAgeLabel = `<div class="trello-card-aging" style="color:purple;">${moment(date).fromNow()}</div>`;
+              // fix after the Trello release around 2023/10/20
+              cards[index].innerHTML = cards[index].innerHTML + trueAgeLabel;
+            }
+          };
+
+          xhr.open("GET", 'https://' + document.domain + cardHref + '.json');
+          xhr.send();
+        }
+      })(index);
+    }
+  }
 }


### PR DESCRIPTION
## Update after the Trello release around 2023/10/20
There was a release of Trello website on 20 Oct 2023, which removed hidden card number and the total number of each list/column. I had to re-implement these features.
It took me some time because Chrome Web Store no longer accepts Manifest V2 extensions. I had to migrate it to Manifest V3.
